### PR TITLE
Replace ElasticTranscoder with MediaConvert

### DIFF
--- a/media-convert-settings.yml
+++ b/media-convert-settings.yml
@@ -1,0 +1,57 @@
+---
+TimecodeConfig:
+  Source: ZEROBASED
+OutputGroups:
+  - CustomName: testing-template
+    Name: Apple HLS
+    Outputs:
+      - Preset: System-Avc_16x9_270p_14_99fps_400kbps
+        NameModifier: /480x270
+      - Preset: System-Avc_16x9_360p_29_97fps_1200kbps
+        NameModifier: /640x360
+      - Preset: System-Avc_16x9_540p_29_97fps_3500kbps
+        NameModifier: /960x540
+      - Preset: System-Avc_16x9_720p_29_97fps_3500kbps
+        NameModifier: /1280x720
+      - Preset: System-Avc_16x9_1080p_29_97fps_8500kbps
+        NameModifier: /1920x1080
+      - Preset: System-Ott_Hls_Ts_Avc_Aac_4x3_1600x1200p_30Hz_8.5Mbps
+        NameModifier: /1600x1200
+    OutputGroupSettings:
+      Type: HLS_GROUP_SETTINGS
+      HlsGroupSettings:
+        ManifestDurationFormat: INTEGER
+        SegmentLength: 2
+        TimedMetadataId3Period: 10
+        CaptionLanguageSetting: OMIT
+        TimedMetadataId3Frame: PRIV
+        CodecSpecification: RFC_4281
+        OutputSelection: MANIFESTS_AND_SEGMENTS
+        ProgramDateTimePeriod: 600
+        MinSegmentLength: 0
+        MinFinalSegmentLength: 0
+        DirectoryStructure: SINGLE_DIRECTORY
+        ProgramDateTime: EXCLUDE
+        SegmentControl: SINGLE_FILE
+        ManifestCompression: NONE
+        ClientCache: ENABLED
+        AudioOnlyHeader: INCLUDE
+        StreamInfResolution: INCLUDE
+AdAvailOffset: 0
+Inputs:
+  - AudioSelectors:
+      Audio Selector 1:
+        Offset: 0
+        DefaultSelection: DEFAULT
+        ProgramSelection: 1
+    VideoSelector:
+      ColorSpace: FOLLOW
+      Rotate: DEGREE_0
+      AlphaBehavior: DISCARD
+    FilterEnable: AUTO
+    PsiControl: USE_PSI
+    FilterStrength: 0
+    DeblockFilter: DISABLED
+    DenoiseFilter: DISABLED
+    InputScanType: AUTO
+    TimecodeSource: ZEROBASED

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@
 # please view the LICENSE file that was distributed
 # with this source code.
 #
-# copyright (c) 2018, Juan Manuel Torres (http://onema.io)
+# copyright (c) 2021, Juan Manuel Torres (http://onema.io)
 #
 # @author Juan Manuel Torres <software@onema.io>
 #
@@ -28,8 +28,6 @@ provider:
       Ref: VideoTable
     QUEUE_URL:
       Ref: TranscodeLoadingQueue
-    PIPELINE_ID:
-      Ref: PipelineId
 
   iamRoleStatements:
     - Effect: Allow
@@ -54,15 +52,6 @@ provider:
         - Fn::Join: [ "/", [ Fn::GetAtt: [ VideoTable, Arn ], "index", "*" ] ]
     - Effect: Allow
       Action:
-        - elastictranscoder:Read*
-        - elastictranscoder:List*
-        - elastictranscoder:*Job
-        - elastictranscoder:*Preset
-      Resource:
-        - Fn::Join: ["", ["arn:aws:elastictranscoder:", Ref: "AWS::Region", ":", Ref: "AWS::AccountId", ":pipeline/", Ref: PipelineId ]]
-        - Fn::Join: ["", ["arn:aws:elastictranscoder:", Ref: "AWS::Region", ":", Ref: "AWS::AccountId", ":preset/*" ]]
-    - Effect: Allow
-      Action:
         - s3:List*
         - sns:List*
       Resource:
@@ -75,6 +64,32 @@ provider:
         - sqs:ReceiveMessage
       Resource:
         - Fn::GetAtt: [ TranscodeLoadingQueue, Arn ]
+    - Effect: Allow
+      Action:
+        - mediaconvert:GetJob
+        - mediaconvert:ListTagsForResource
+        - mediaconvert:GetJobTemplate
+        - mediaconvert:UntagResource
+        - mediaconvert:TagResource
+        - mediaconvert:CreateJob
+      Resource:
+        - Fn::GetAtt: [StreamingServiceMediaConvert, Arn]
+        - Fn::Join: ["", ["arn:aws:mediaconvert:", Ref: "AWS::Region", ":", Ref: "AWS::AccountId", ":jobs/*"] ]
+        - Fn::Join: ["", ["arn:aws:mediaconvert:", Ref: "AWS::Region", ":", Ref: "AWS::AccountId", ":queues/*"] ]
+        - Fn::Join: ["", ["arn:aws:mediaconvert:", Ref: "AWS::Region", ":", Ref: "AWS::AccountId", ":presets/allow*"] ]
+    - Effect: Allow
+      Action:
+        - mediaconvert:ListQueues
+        - mediaconvert:DescribeEndpoints
+        - mediaconvert:ListPresets
+        - mediaconvert:ListJobTemplates
+      Resource: "*"
+    - Effect: Allow
+      Action:
+        - iam:PassRole
+        - iam:ListRoles
+      "Resource":
+        - "arn:aws:iam::*:role/*"
 
 package:
   artifact: transcode/build/libs/transcode-0.0.1-SNAPSHOT-all.jar
@@ -101,6 +116,12 @@ functions:
   transcodingJob:
     handler: io.onema.streaming.transcode.transcoderstarter.TranscodeStarterFunction::handleRequest
     environment:
+      JOB_TEMPLATE_NAME:
+        Ref: StreamingServiceMediaConvert
+      OUTPUT_BUCKET_NAME:
+        Ref: OutputBucket
+      MEDIA_CONVERT_ROLE:
+        Fn::GetAtt : [MediaConvertRole, Arn]
 
     events:
       - s3:
@@ -160,11 +181,30 @@ resources:
     OutputBucket:
       Type: AWS::S3::Bucket
 
-  Parameters:
-    PipelineId:
-      Default: "${opt:pipelineId}"
-      Description: The ID of the Elastic Transcoder pipeline
-      Type: String
+    StreamingServiceMediaConvert:
+      Type: AWS::MediaConvert::JobTemplate
+      Properties:
+        Description: Streaming service media convert for HLS
+        SettingsJson: ${file(media-convert-settings.yml)}
+        StatusUpdateInterval: SECONDS_30
+
+    MediaConvertRole:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - mediaconvert.amazonaws.com
+              Action:
+                - sts:AssumeRole
+        Path: /
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/AmazonS3FullAccess
+          - arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess
+
   Outputs:
     InputBucketName:
       Value:

--- a/transcode/build.gradle.kts
+++ b/transcode/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
     val awsSdk1Version = "1.11.923"
-    val awsSdk2Version = "2.15.53"
+    val awsSdk2Version = "2.15.66"
     val arrowVersion = "0.11.0"
 
     implementation(kotlin("stdlib"))
@@ -30,10 +30,10 @@ dependencies {
     // AWS
     implementation("com.amazonaws:aws-lambda-java-events:3.2.0")
     implementation("com.amazonaws:aws-lambda-java-core:1.2.1")
-    implementation("com.amazonaws:aws-java-sdk-elastictranscoder:$awsSdk1Version")
     implementation("com.amazonaws:aws-java-sdk-dynamodb:$awsSdk1Version")
     implementation("software.amazon.awssdk:s3:$awsSdk2Version")
     implementation("software.amazon.awssdk:sqs:$awsSdk2Version")
+    implementation("software.amazon.awssdk:mediaconvert:$awsSdk2Version")
 
     // Logging
     implementation("io.symphonia:lambda-logging:1.0.3")

--- a/transcode/src/main/kotlin/io/onema/streaming/transcode/BaseHandler.kt
+++ b/transcode/src/main/kotlin/io/onema/streaming/transcode/BaseHandler.kt
@@ -12,11 +12,10 @@
 package io.onema.streaming.transcode
 
 import arrow.core.Either
-import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
 import com.fasterxml.jackson.datatype.joda.JodaModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import kotlinx.coroutines.*
+import kotlinx.coroutines.runBlocking
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -32,11 +31,8 @@ abstract class BaseHandler<TEvent, TOut> : RequestHandler<TEvent, TOut> {
         mapper.registerModule(JodaModule())
     }
 
-    fun handle(func: () -> TOut): TOut = runBlocking {
-        val result = Either.catch {
-            func()
-        }
-        when(result) {
+    fun handle(lambdaFunction: () -> TOut): TOut = runBlocking {
+        when(val result = Either.catch { lambdaFunction() }) {
             is Either.Right -> {
                 log.info("ALL DONE!")
                 result.b

--- a/transcode/src/main/kotlin/io/onema/streaming/transcode/extensions/S3Extensions.kt
+++ b/transcode/src/main/kotlin/io/onema/streaming/transcode/extensions/S3Extensions.kt
@@ -24,7 +24,8 @@ import java.io.File
 
 val log: Logger = LoggerFactory.getLogger(S3EventNotificationRecord::class.java)
 
-fun S3EventNotificationRecord.origin(): String = "s3://${bucket()}.s3.amazonaws.com${path()}"
+fun S3EventNotificationRecord.origin(): String = "s3://${bucket()}${path()}"
+fun S3EventNotificationRecord.keyOrigin(): String = "s3://${bucket()}/${key()}"
 fun S3EventNotificationRecord.bucket(): String = s3.bucket.name
 fun S3EventNotificationRecord.key(): String = s3.`object`.urlDecodedKey
 fun S3EventNotificationRecord.path(): String = File(s3.`object`.urlDecodedKey).parent

--- a/transcode/src/main/kotlin/io/onema/streaming/transcode/transcoderstarter/TranscodeStarterLogic.kt
+++ b/transcode/src/main/kotlin/io/onema/streaming/transcode/transcoderstarter/TranscodeStarterLogic.kt
@@ -11,44 +11,52 @@
 
 package io.onema.streaming.transcode.transcoderstarter
 
-import com.amazonaws.services.elastictranscoder.AmazonElasticTranscoder
-import com.amazonaws.services.elastictranscoder.model.CreateJobOutput
-import com.amazonaws.services.elastictranscoder.model.CreateJobRequest
-import com.amazonaws.services.elastictranscoder.model.JobInput
 import com.amazonaws.services.lambda.runtime.events.S3Event
 import io.onema.streaming.transcode.extensions.firstRecord
+import io.onema.streaming.transcode.extensions.keyOrigin
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import software.amazon.awssdk.services.mediaconvert.MediaConvertClient
+import software.amazon.awssdk.services.mediaconvert.model.*
 
 class TranscodeStarterLogic(
-    private val pipelineId: String,
-    private val amazonElasticTranscoder: AmazonElasticTranscoder,
-    private val presets: Map<String, String>) {
+    private val jobTemplateName: String,
+    private val outputBucket: String,
+    private val mediaConvertRole: String,
+    private val mediaConverter: MediaConvertClient) {
 
     private val log: Logger = LoggerFactory.getLogger(javaClass)
 
     fun process(event: S3Event) {
         val record = event.firstRecord()
-        val inputKey = record.s3.`object`.urlDecodedKey
         log.info("Event for Bucket: ${record.s3.bucket} Key: ${record.s3.`object`.key}")
+        val output = "s3://$outputBucket/"
 
-        val input = JobInput().withKey(inputKey)
-
-        val videoName = inputKey.split('.').first() //inputKey.inputKeyToOutputKey()
-        val outputs: List<CreateJobOutput> = presets.map { (key, presetId) ->
-            CreateJobOutput()
-                .withKey("$key.ts")
-                .withPresetId(presetId)
-        }
-
-        val outputKeyPrefix = "$videoName/"
-        val createJobRequest = CreateJobRequest()
-            .withPipelineId(pipelineId)
-            .withInput(input)
-            .withOutputKeyPrefix(outputKeyPrefix)
-            .withOutputs(outputs)
-        val job = amazonElasticTranscoder.createJob(createJobRequest).job
-        log.info("OUTPUT KEY PREFIX: $outputKeyPrefix")
-        log.info("JOB ID: " + job?.id)
+        val inputs = Input
+            .builder()
+            .fileInput(record.keyOrigin())
+            .build()
+        val hlsGroupSettings = HlsGroupSettings
+            .builder()
+            .destination(output)
+            .build()
+        val outputGroupSettings = OutputGroupSettings
+            .builder()
+            .hlsGroupSettings(hlsGroupSettings)
+            .build()
+        val outputs = OutputGroup.builder()
+            .name("Apple HLS")
+            .outputGroupSettings(outputGroupSettings)
+            .build()
+        val settings = JobSettings.builder()
+            .inputs(inputs)
+            .outputGroups(outputs)
+            .build()
+        val createJobRequest = CreateJobRequest.builder()
+            .jobTemplate(jobTemplateName)
+            .role(mediaConvertRole)
+            .settings(settings)
+            .build()
+        mediaConverter.createJob(createJobRequest)
     }
 }


### PR DESCRIPTION
- Replace ElasticTranscoder with MediaConvert
- update metadata loader to use IO.fx
- the serverless.yml definition creates a media convert job template with settings for the following resolutions: 
    - `480x270`
    - `640x360`
    - `960x540`
    - `1280x720`
    - `1920x1080`
    - `1600x1200`